### PR TITLE
Custom Path Prefix

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,4 +1,5 @@
 module.exports = {
+	pathPrefix: process.env.PATH_PREFIX || "",
 	siteMetadata: {
 		title: `Library of Open Source Hardware`,
 		description: `We are aiming to build the (real) Internet of Things – the Internet of Open Hardware.`,


### PR DESCRIPTION
## Description

This PR allows the frontend to be build with a custom path prefix, so the site can be hosted in a non-root location. The path prefix can be passed to the build process as follows:

```sh
PATH_PREFIX="/foo" gatsby build --prefix-paths
```
