### PR TITLE
Make hardcoded values configurable

### DIFF
--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -1,0 +1,15 @@
+import env from "dotenv";
+
+env.config();
+
+export const WIKIBASE_API_URL =
+  process.env.WIKIBASE_API_URL || "https://losh.ose-germany.de";
+export const ELASTIC_API_URL =
+  process.env.ELASTIC_API_URL || "http://localhost:9200";
+export const FUNCTIONAL_DESCRIPTION_PROPERTY =
+  process.env.FUNCTIONAL_DESCRIPTION_PROPERTY || "P109";
+export const LICENSE_PROPERTY = process.env.LICENSE_PROPERTY || "P1452";
+export const TYPE_PROPERTY = process.env.TYPE_PROPERTY || "P1426";
+export const PORT = process.env.PORT || 3000;
+export const ELASTIC_INDEX =
+  process.env.ELASTIC_INDEX || "losh_01_content_first";

--- a/packages/server/src/dataSources/elastic/index.ts
+++ b/packages/server/src/dataSources/elastic/index.ts
@@ -3,6 +3,12 @@ import { LICENSES } from "../../constants";
 import { SearchItemsArgs, LicenseValue } from "../../types";
 import { ElasticSearchItemsResponse } from "./types";
 import { DataSource } from "apollo-datasource";
+import {
+  ELASTIC_INDEX,
+  FUNCTIONAL_DESCRIPTION_PROPERTY,
+  LICENSE_PROPERTY,
+  TYPE_PROPERTY,
+} from "../../config";
 
 class ElasticDataSource extends DataSource {
   elastic: Client;
@@ -21,7 +27,7 @@ class ElasticDataSource extends DataSource {
     const query = this.generateSearchQuery({ search, license });
 
     const { body } = await this.elastic.search({
-      index: "losh_01_content_first",
+      index: ELASTIC_INDEX,
       body: {
         from: (page - 1) * pageSize,
         size: pageSize,
@@ -43,7 +49,7 @@ class ElasticDataSource extends DataSource {
     }
 
     const values = LICENSES[license].map(
-      (l) => `P1452=https://spdx.org/licenses/${l}`
+      (l) => `${LICENSE_PROPERTY}=https://spdx.org/licenses/${l}`
     );
 
     return values.map((v) => ({
@@ -66,8 +72,7 @@ class ElasticDataSource extends DataSource {
           search && this.generateCombinedTermSearch(search),
           {
             match: {
-              statement_keywords:
-                "P1426=https://github.com/OPEN-NEXT/OKH-LOSH/raw/master/OKH-LOSH.ttl#Module",
+              statement_keywords: `${TYPE_PROPERTY}=https://github.com/OPEN-NEXT/OKH-LOSH/raw/master/OKH-LOSH.ttl#Module`,
             },
           },
           {
@@ -104,7 +109,7 @@ class ElasticDataSource extends DataSource {
 
     return {
       query_string: {
-        query: `P109=*${escapedSearchTerm}*`,
+        query: `${FUNCTIONAL_DESCRIPTION_PROPERTY}=*${escapedSearchTerm}*`,
         fields: ["statement_keywords"],
         // Ideally this functional description value should be indexed separately in Elasticsearch so that it can be
         // queried more efficiently as mentioned in the description of #79.

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -5,21 +5,14 @@ import compression from "compression";
 import cors from "cors";
 import helmet from "helmet";
 import { schema } from "./schema";
-import env from "dotenv";
 import ElasticDataSource from "./dataSources/elastic";
 import WikibaseDataSource from "./dataSources/wikibase";
+import { ELASTIC_API_URL, PORT, WIKIBASE_API_URL } from "./config";
 
-env.config();
-
-const PORT = process.env.PORT || 3000;
 const app = express();
 app.use("*", (cors as any)());
 app.use(helmet());
 app.use(compression());
-
-const ELASTIC_API_URL = process.env.ELASTIC_API_URL || "http://localhost:9200";
-const WIKIBASE_API_URL =
-  process.env.WIKIBASE_API_URL || "https://losh.ose-germany.de";
 
 const dataSources = {
   elasticAPI: new ElasticDataSource(ELASTIC_API_URL),


### PR DESCRIPTION
Having Properties, elastic index name etc configurable makes it easier when working locally and not against the production wikibase/elastic.