### PR TITLE
server: add organizations list endpoint

### DIFF
--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -4,12 +4,28 @@ env.config();
 
 export const WIKIBASE_API_URL =
   process.env.WIKIBASE_API_URL || "https://losh.ose-germany.de";
+
 export const ELASTIC_API_URL =
   process.env.ELASTIC_API_URL || "http://localhost:9200";
+
 export const FUNCTIONAL_DESCRIPTION_PROPERTY =
   process.env.FUNCTIONAL_DESCRIPTION_PROPERTY || "P109";
+
 export const LICENSE_PROPERTY = process.env.LICENSE_PROPERTY || "P1452";
+
 export const TYPE_PROPERTY = process.env.TYPE_PROPERTY || "P1426";
+
+export const ORGANIZATION_PROPERTY = process.env.ORGANIZATION_PROPERTY || "P49";
+
 export const PORT = process.env.PORT || 3000;
+
 export const ELASTIC_INDEX =
   process.env.ELASTIC_INDEX || "losh_01_content_first";
+
+export const QUERY_SERVICE_URL =
+  process.env.QUERY_SERVICE_URL ||
+  "https://losh.ose-germany.de/qs/proxy/wdqs/bigdata/namespace/wdq/sparql";
+
+export const SPARQL_PROPERTY_URI_PREFIX =
+  process.env.SPARQL_PROPERTY_URI_PREFIX ||
+  "https://losh.ose-germany.de/prop/direct/";

--- a/packages/server/src/dataSources/index.ts
+++ b/packages/server/src/dataSources/index.ts
@@ -1,15 +1,19 @@
 import ElasticDataSource from "./elastic";
 import WikibaseDataSource from "./wikibase";
+import { QueryServiceDataSource } from "./queryService";
 
 export const dataSources = (
   ELASTIC_API_URL: string,
-  WIKIBASE_API_URL: string
+  WIKIBASE_API_URL: string,
+  QUERY_SERVICE_URL: string
 ) => {
   console.log(`Elastic API URL: ${ELASTIC_API_URL}`);
   console.log(`Wikibase API URL: ${WIKIBASE_API_URL}`);
+  console.log(`Query Service URL: ${QUERY_SERVICE_URL}`);
   return {
     elasticAPI: new ElasticDataSource(ELASTIC_API_URL),
     wikibaseAPI: new WikibaseDataSource(WIKIBASE_API_URL),
+    queryService: new QueryServiceDataSource(QUERY_SERVICE_URL),
   };
 };
 

--- a/packages/server/src/dataSources/queryService/index.ts
+++ b/packages/server/src/dataSources/queryService/index.ts
@@ -1,0 +1,34 @@
+import { DataSource } from "apollo-datasource";
+import {
+  ORGANIZATION_PROPERTY,
+  SPARQL_PROPERTY_URI_PREFIX,
+} from "../../config";
+import axios from "axios";
+
+export class QueryServiceDataSource extends DataSource {
+  private endpointUrl: string;
+
+  constructor(endpointUrl: string) {
+    super();
+
+    this.endpointUrl = endpointUrl;
+  }
+
+  async getOrganizations(): Promise<{ name: string }[]> {
+    const query = `
+      SELECT DISTINCT ?org
+      WHERE
+      {
+        ?item <${SPARQL_PROPERTY_URI_PREFIX}${ORGANIZATION_PROPERTY}> ?org .
+      }`;
+
+    const { data } = await axios.get<any>(
+      `${this.endpointUrl}?query=${encodeURIComponent(query)}`,
+      { headers: { Accept: "application/sparql-results+json" } }
+    );
+
+    return data.results.bindings.map(({ org }: { org: { value: string } }) => {
+      return { name: org.value };
+    });
+  }
+}

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -7,7 +7,13 @@ import helmet from "helmet";
 import { schema } from "./schema";
 import ElasticDataSource from "./dataSources/elastic";
 import WikibaseDataSource from "./dataSources/wikibase";
-import { ELASTIC_API_URL, PORT, WIKIBASE_API_URL } from "./config";
+import {
+  ELASTIC_API_URL,
+  PORT,
+  QUERY_SERVICE_URL,
+  WIKIBASE_API_URL,
+} from "./config";
+import { QueryServiceDataSource } from "./dataSources/queryService";
 
 const app = express();
 app.use("*", (cors as any)());
@@ -17,6 +23,7 @@ app.use(compression());
 const dataSources = {
   elasticAPI: new ElasticDataSource(ELASTIC_API_URL),
   wikibaseAPI: new WikibaseDataSource(WIKIBASE_API_URL),
+  queryService: new QueryServiceDataSource(QUERY_SERVICE_URL),
 };
 
 const startServer = async () => {

--- a/packages/server/src/service/serviceResolver.ts
+++ b/packages/server/src/service/serviceResolver.ts
@@ -35,6 +35,14 @@ const ServiceResolvers = {
         throw new ApolloError(error as any);
       }
     },
+
+    async organizations(
+      _: never,
+      _args: never,
+      { dataSources }: { dataSources: DataSources }
+    ): Promise<{ name: string }[]> {
+      return dataSources.queryService.getOrganizations();
+    },
   },
 };
 

--- a/packages/server/src/service/serviceSchema.ts
+++ b/packages/server/src/service/serviceSchema.ts
@@ -33,6 +33,10 @@ export const ServiceTypeDefs = gql`
       license: String
     ): SearchResponse
     getItem(id: String): ItemResponse
+    organizations: [Organization]
+  }
+  type Organization {
+    name: String
   }
   type ItemResponse {
     id: String


### PR DESCRIPTION
This adds an `organizations` field to the GraphQL endpoint. The result is not yet cached.

Example (using the real endpoint):
Request: `curl --request POST   --header 'content-type: application/json'   --url 'localhost:3000/graphql'   --data '{"query":"query { organizations {name}}"}'`
Result: 
```
{"data":{"organizations":[{"name":"AgriLab"},{"name":"FabLab Santander"},{"name":"Aretech"},{"name":"fab lab.au - UFMT"},{"name":"Fablab Fabbulle"},{"name":"Popup Moi"},{"name":"Resilience Collective Fablabs"},{"name":"Distributed Design Studio"},{"name":"Working Group Fab Labs & SDGs"},{"name":"FabLab Barcelona"},{"name":"Helpful Devices"},{"name":"MK Pro"},{"name":"OSBeehives"},{"name":"Distributed Design"},{"name":"FabLab Budapest"},{"name":"Franzininho"},{"name":"UBO Open Factory"},{"name":"CAROLA"},{"name":"Snapmaker"},{"name":"Field Ready"},{"name":"CubeSpawn Project"},{"name":"FabLab Centro de Innovación UC"},{"name":"Delft Open Hardware"},{"name":"MEKANIKA"},{"name":"floraLynk"},{"name":"yquere"},{"name":"JetClay"},{"name":"Plastic Scanner"},{"name":"e-NABLE"},{"name":"Wikifactory"},{"name":"WeMake"},{"name":"Elektric Works"},{"name":"thr34d5"},{"name":"smartDIYs"},{"name":"Otto DIY"},{"name":"The Weedo Life"},{"name":"HertzLovers"},{"name":"Colaborativa.eu"},{"name":"MakeFashionEdu"},{"name":"Leka"},{"name":"Growstack"},{"name":"WIKISPEED Inc"},{"name":"ONG AYÚDAME3D"},{"name":"FabLab Benfica"},{"name":"FabLab SUPSI"},{"name":"Wave Ceramics"},{"name":"MAKILAB"},{"name":"Alquimétricos"},{"name":"SDG Solution Space"},{"name":"FabLab U. de Chile"},{"name":"Makers Vs Covid"},{"name":"Fablab_Icam"},{"name":"Kuestenbiene"},{"name":"COVID 19 Makers Madrid"},{"name":"Fablab Onaki"},{"name":"Holybro"},{"name":"Sinestesia.cc"},{"name":"I+D+Arq"},{"name":"Dronecoria"},{"name":"Sono Motors GmbH"},{"name":"échoFab"},{"name":"Lab de Fabricación UDLA_Scl"},{"name":"柴火创客空间Chaihuo x.factory"},{"name":"Ottawa Design Hub"},{"name":"Fablab Bratislava at Slovak Centre of Scientific and Technical Information (SCSTI)"},{"name":"Atelio"},{"name":"Flipper Devices Inc."},{"name":"FarmBot Inc."},{"name":"OpenSourceImaging"},{"name":"OSE Germany e.V."}]}}
```

Part of #91