### PR TITLE
Repos endpoint

### DIFF
--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -17,6 +17,8 @@ export const TYPE_PROPERTY = process.env.TYPE_PROPERTY || "P1426";
 
 export const ORGANIZATION_PROPERTY = process.env.ORGANIZATION_PROPERTY || "P49";
 
+export const REPO_HOST_PROPERTY = process.env.REPO_HOST_PROPERTY || "P112";
+
 export const PORT = process.env.PORT || 3000;
 
 export const ELASTIC_INDEX =

--- a/packages/server/src/dataSources/queryService/index.ts
+++ b/packages/server/src/dataSources/queryService/index.ts
@@ -1,5 +1,6 @@
 import { DataSource } from "apollo-datasource";
 import {
+  REPO_HOST_PROPERTY,
   ORGANIZATION_PROPERTY,
   SPARQL_PROPERTY_URI_PREFIX,
 } from "../../config";
@@ -20,6 +21,14 @@ export class QueryServiceDataSource extends DataSource {
     );
 
     return values.map((v) => ({ name: v }));
+  }
+
+  async getRepos(): Promise<{ host: string }[]> {
+    const values = await this.getValuesOfStatementsWithProperty(
+      REPO_HOST_PROPERTY
+    );
+
+    return values.map((v) => ({ host: v }));
   }
 
   private async getValuesOfStatementsWithProperty(

--- a/packages/server/src/dataSources/queryService/index.ts
+++ b/packages/server/src/dataSources/queryService/index.ts
@@ -15,11 +15,21 @@ export class QueryServiceDataSource extends DataSource {
   }
 
   async getOrganizations(): Promise<{ name: string }[]> {
+    const values = await this.getValuesOfStatementsWithProperty(
+      ORGANIZATION_PROPERTY
+    );
+
+    return values.map((v) => ({ name: v }));
+  }
+
+  private async getValuesOfStatementsWithProperty(
+    propertyId: string
+  ): Promise<string[]> {
     const query = `
-      SELECT DISTINCT ?org
+      SELECT DISTINCT ?result
       WHERE
       {
-        ?item <${SPARQL_PROPERTY_URI_PREFIX}${ORGANIZATION_PROPERTY}> ?org .
+        ?item <${SPARQL_PROPERTY_URI_PREFIX}${propertyId}> ?result .
       }`;
 
     const { data } = await axios.get<any>(
@@ -27,8 +37,8 @@ export class QueryServiceDataSource extends DataSource {
       { headers: { Accept: "application/sparql-results+json" } }
     );
 
-    return data.results.bindings.map(({ org }: { org: { value: string } }) => {
-      return { name: org.value };
-    });
+    return data.results.bindings.map(
+      ({ result }: { result: { value: string } }) => result.value
+    );
   }
 }

--- a/packages/server/src/service/serviceResolver.ts
+++ b/packages/server/src/service/serviceResolver.ts
@@ -43,6 +43,14 @@ const ServiceResolvers = {
     ): Promise<{ name: string }[]> {
       return dataSources.queryService.getOrganizations();
     },
+
+    async repos(
+      _: never,
+      _args: never,
+      { dataSources }: { dataSources: DataSources }
+    ): Promise<{ host: string }[]> {
+      return dataSources.queryService.getRepos();
+    },
   },
 };
 

--- a/packages/server/src/service/serviceSchema.ts
+++ b/packages/server/src/service/serviceSchema.ts
@@ -35,9 +35,13 @@ export const ServiceTypeDefs = gql`
     ): SearchResponse
     getItem(id: String): ItemResponse
     organizations: [Organization]
+    repos: [Repo]
   }
   type Organization @cacheControl(maxAge: 60) {
     name: String
+  }
+  type Repo @cacheControl(maxAge: 60) {
+    host: String
   }
   type ItemResponse {
     id: String


### PR DESCRIPTION
Adds a `repos` endpoint to GraphQL, which, like the one for organizations is cached for 1 minute.

```
$ curl --request POST   --header 'content-type: application/json'   --url 'localhost:3000/graphql'   --data '{"query":"query { repos {host}}"}'

{"data":{"repos":[{"host":"wikifactory.com"},{"host":"github.com"},{"host":"source.mnt.re"},{"host":"en.oho.wiki"},{"host":"gitlab.com"}]}}
```