### PR TITLE
Enable filtering by repo host

### DIFF
--- a/packages/client/src/context/query-context.tsx
+++ b/packages/client/src/context/query-context.tsx
@@ -54,6 +54,7 @@ export const QueryProvider: React.FC = ({ children }) => {
 			pageSize,
 			licenseFilter: filters.license,
 			organizationFilter: filters.organization,
+			repoHostFilter: filters.repoHost,
 		};
 
 		getItems({ variables });

--- a/packages/client/src/queries/get-items.ts
+++ b/packages/client/src/queries/get-items.ts
@@ -14,6 +14,7 @@ export const GET_ITEMS = gql`
 		$pageSize: Int
 		$licenseFilter: String
 		$organizationFilter: String
+		$repoHostFilter: String
 	) {
 		searchItems(
 			query: $query
@@ -21,6 +22,7 @@ export const GET_ITEMS = gql`
 			pageSize: $pageSize
 			license: $licenseFilter
 			organization: $organizationFilter
+			repoHost: $repoHostFilter
 		) {
 			total
 			items {

--- a/packages/server/src/dataSources/elastic/index.ts
+++ b/packages/server/src/dataSources/elastic/index.ts
@@ -8,6 +8,7 @@ import {
   FUNCTIONAL_DESCRIPTION_PROPERTY,
   LICENSE_PROPERTY,
   ORGANIZATION_PROPERTY,
+  REPO_HOST_PROPERTY,
   TYPE_PROPERTY,
 } from "../../config";
 
@@ -23,10 +24,16 @@ class ElasticDataSource extends DataSource {
     query: search,
     license,
     organization,
+    repoHost,
     page,
     pageSize,
   }: SearchItemsArgs): Promise<ElasticSearchItemsResponse> {
-    const query = this.generateSearchQuery({ search, license, organization });
+    const query = this.generateSearchQuery({
+      search,
+      license,
+      organization,
+      repoHost,
+    });
     const { body } = await this.elastic.search({
       index: ELASTIC_INDEX,
       body: {
@@ -65,10 +72,12 @@ class ElasticDataSource extends DataSource {
     search,
     license,
     organization,
+    repoHost,
   }: {
     search: string;
     license: LicenseValue;
     organization: string;
+    repoHost: string;
   }) => {
     return {
       bool: {
@@ -83,6 +92,11 @@ class ElasticDataSource extends DataSource {
             this.generateExactPropertyValueMatchQuery(
               ORGANIZATION_PROPERTY,
               organization
+            ),
+          repoHost &&
+            this.generateExactPropertyValueMatchQuery(
+              REPO_HOST_PROPERTY,
+              repoHost
             ),
         ].filter(Boolean),
       },

--- a/packages/server/src/service/serviceSchema.ts
+++ b/packages/server/src/service/serviceSchema.ts
@@ -32,6 +32,7 @@ export const ServiceTypeDefs = gql`
       pageSize: Int
       license: String
       organization: String
+      repoHost: String
     ): SearchResponse
     getItem(id: String): ItemResponse
     organizations: [Organization]

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -2,6 +2,7 @@ export interface SearchItemsArgs {
   query: string;
   license: LicenseValue;
   organization: string;
+  repoHost: string;
   page: number;
   pageSize: number;
 }


### PR DESCRIPTION
Wires up the dopdown added in #102 and adds the additional filter to the elastic query.

Fixes #93 