### PR TITLE
Fix 404 error for items without terms

### DIFF
--- a/packages/server/src/dataSources/wikibase/index.ts
+++ b/packages/server/src/dataSources/wikibase/index.ts
@@ -44,9 +44,7 @@ export default class WikibaseDataSource extends HTTPDataSource {
       .then((res: any) => this.parseData(res.data.entities[itemId]))
       .then(async (item) => {
         const promises = Object.entries(item)
-          .filter(([key, value]) => {
-            if (value.datatype === "wikibase-item") return [key, value];
-          })
+          .filter(([_, value]) => value && value.datatype === "wikibase-item")
           .map(async ([key, value]: [string, DataValueItem]) => {
             const id = value.datavalue.value;
             const itemUrl = this.wbk.getEntities([id]);


### PR DESCRIPTION
There were a few things wrong with the line that caused this bug:
1. It iterates over all fields of a simplified item object which
   contained the name (= english label) as well as all statements
   mapped by Property IDs. It then attempts to filter everything but
   statements with item values by checking `value.datatype`, which
   errored because it also checked the name which is `undefined`.
2. It returns the key/value pair from Array.prototype.filter which
   should just return a boolean value.

Fixes #92