### PR TITLE
Avoid version hashes overlapping with next cell

### DIFF
--- a/packages/client/src/components/hardware-table.tsx
+++ b/packages/client/src/components/hardware-table.tsx
@@ -25,6 +25,7 @@ const columns: ColumnsType<HardwareData> = [
 		dataIndex: Properties.VERSION,
 		render: (v, record) => record.version?.datavalue.value,
 		responsive: ["lg"],
+		ellipsis: true,
 	},
 	{
 		title: "License",


### PR DESCRIPTION
Prevents overflowing and adds an ellipsis in case the version hash is too long:

![Screenshot from 2022-01-28 13-27-39](https://user-images.githubusercontent.com/453024/151547087-a18fc81c-bc28-4f75-8125-592be37fca22.png)

Fixes #84