### PR TITLE
Make search clearable

### DIFF
--- a/packages/client/src/components/search-box.tsx
+++ b/packages/client/src/components/search-box.tsx
@@ -21,6 +21,7 @@ export const SearchBox: React.FC = () => {
 			<Input.Search
 				id="search"
 				placeholder="input search text"
+				allowClear={true}
 				onSearch={handleSearchChange}
 				onChange={(e) => setCurrentValue(e.target.value)}
 				value={currentValue}


### PR DESCRIPTION
Adds a little clear icon to the search field. Clicking it clears the field and resets the search.
![Screenshot from 2022-01-28 16-00-25](https://user-images.githubusercontent.com/453024/151571325-53673f6b-b51a-4320-b898-366db0b41f00.png)

Fixes #88