### PR TITLE
Use built-in clear instead of custom field

### DIFF
--- a/packages/client/src/components/__tests__/__snapshots__/filter.test.tsx.snap
+++ b/packages/client/src/components/__tests__/__snapshots__/filter.test.tsx.snap
@@ -59,7 +59,7 @@ exports[`Filter renders correctly 1`] = `
     </Button>
   </Dropdown>
   <Select
-    defaultValue="-1"
+    allowClear={true}
     filterOption={[Function]}
     onChange={[Function]}
     optionFilterProp="children"
@@ -70,12 +70,6 @@ exports[`Filter renders correctly 1`] = `
         "width": 240,
       }
     }
-  >
-    <Unknown
-      value="-1"
-    >
-      Any organization
-    </Unknown>
-  </Select>
+  />
 </Space>
 `;

--- a/packages/client/src/components/filter.tsx
+++ b/packages/client/src/components/filter.tsx
@@ -125,7 +125,7 @@ const Filter: React.FC<FilterProps> = ({ filters, onFilterChange }) => {
 				</Button>
 			</Dropdown>
 			<Select
-				defaultValue={RESET_FILTER}
+				allowClear
 				style={{ width: 240 }}
 				showSearch
 				placeholder="Organization"
@@ -135,7 +135,6 @@ const Filter: React.FC<FilterProps> = ({ filters, onFilterChange }) => {
 					option!.children.toLowerCase().indexOf(input.toLowerCase()) >= 0
 				}
 			>
-				<Option value={RESET_FILTER}>Any organization</Option>
 				{(organizations || []).map((org: string) => (
 					<Option key={org} value={org}>
 						{org}

--- a/packages/client/src/components/search-box.tsx
+++ b/packages/client/src/components/search-box.tsx
@@ -21,7 +21,7 @@ export const SearchBox: React.FC = () => {
 			<Input.Search
 				id="search"
 				placeholder="input search text"
-				allowClear={true}
+				allowClear
 				onSearch={handleSearchChange}
 				onChange={(e) => setCurrentValue(e.target.value)}
 				value={currentValue}


### PR DESCRIPTION
This adds a little clear icon to the select field instead of using the custom "Any organization" field.