### PR TITLE
Skip empty linked files

### DIFF
--- a/packages/client/src/components/detail-rows/detail-row-linked-files.tsx
+++ b/packages/client/src/components/detail-rows/detail-row-linked-files.tsx
@@ -15,10 +15,10 @@ const generateLinkedFiles = (data: HardwareData) => {
 		"hasManufacturingInstructions",
 		"hasManifestFile",
 	].forEach((propertyName) => {
-		if (data[propertyName]) {
-			const url =
-				data[propertyName].datavalue.result.originalUrl ||
-				data[propertyName].datavalue.result.identifier;
+		const url =
+			data[propertyName]?.datavalue.result.originalUrl ||
+			data[propertyName]?.datavalue.result.identifier;
+		if (url) {
 			relatedUrls.push({
 				title: data[propertyName].datavalue.result.name,
 				value: url?.datavalue.value,

--- a/packages/client/src/components/detail-rows/detail-row-linked-files.tsx
+++ b/packages/client/src/components/detail-rows/detail-row-linked-files.tsx
@@ -20,7 +20,9 @@ const generateLinkedFiles = (data: HardwareData) => {
 			data[propertyName]?.datavalue.result.identifier;
 		if (url) {
 			relatedUrls.push({
-				title: data[propertyName].datavalue.result.name,
+				title:
+					data[propertyName].datavalue.result.name ||
+					data[propertyName].datavalue.result.id,
 				value: url?.datavalue.value,
 			});
 		}

--- a/packages/client/src/components/detail-rows/detail-row-linked-files.tsx
+++ b/packages/client/src/components/detail-rows/detail-row-linked-files.tsx
@@ -7,48 +7,24 @@ interface DetailRowLinkedFilesProps {
 }
 
 const generateLinkedFiles = (data: HardwareData) => {
-	const relatedUrls = [];
+	const relatedUrls: { title: string; value: string }[] = [];
 
-	if (data.hasReadme) {
-		const url =
-			data.hasReadme.datavalue.result.originalUrl ||
-			data.hasReadme.datavalue.result.identifier;
-		relatedUrls.push({
-			title: data.hasReadme.datavalue.result.name,
-			value: url?.datavalue.value,
-		});
-	}
-
-	if (data.hasUserManual) {
-		const url =
-			data.hasUserManual.datavalue.result.originalUrl ||
-			data.hasUserManual.datavalue.result.identifier;
-		relatedUrls.push({
-			title: data.hasUserManual.datavalue.result.name,
-			value: url?.datavalue.value,
-		});
-	}
-
-	if (data.hasManufacturingInstructions) {
-		const url =
-			data.hasManufacturingInstructions.datavalue.result.originalUrl ||
-			data.hasManufacturingInstructions.datavalue.result.identifier;
-		relatedUrls.push({
-			title: data.hasManufacturingInstructions.datavalue.result.name,
-			value: url?.datavalue.value,
-		});
-	}
-
-	if (data.hasManifestFile) {
-		const url =
-			data.hasManifestFile.datavalue.result.originalUrl ||
-			data.hasManifestFile.datavalue.result.identifier;
-
-		relatedUrls.push({
-			title: data.hasManifestFile.datavalue.result.name,
-			value: url?.datavalue.value,
-		});
-	}
+	[
+		"hasReadme",
+		"hasUserManual",
+		"hasManufacturingInstructions",
+		"hasManifestFile",
+	].forEach((propertyName) => {
+		if (data[propertyName]) {
+			const url =
+				data[propertyName].datavalue.result.originalUrl ||
+				data[propertyName].datavalue.result.identifier;
+			relatedUrls.push({
+				title: data[propertyName].datavalue.result.name,
+				value: url?.datavalue.value,
+			});
+		}
+	});
 
 	return relatedUrls;
 };


### PR DESCRIPTION
e4a60be959a0564e330e205ce2234e3877224b9e refactors the linked file url building a bit
45e47ac58be8cd7cd69a6ed7f097cd18a186efbb and 8d19169536adf679623a1f31c867a3447d2dc9d2 are the fix.

It turns out that the issue displayed in the screenshot in #87 isn't that there is no linked file (there is!) but the item that is linked has no english label, which is why there is a bullet point with no text. This PR changes the link building logic so that 1) if there's no URL, the field is skipped and 2) if there is a URL but no label, it shows the item id.

Fixes #87 