### PR TITLE
Fix fileUrl spelling per label on the live site

### DIFF
--- a/packages/client/src/components/detail-content.tsx
+++ b/packages/client/src/components/detail-content.tsx
@@ -28,7 +28,7 @@ const renderImage = (
 	}
 
 	const { result } = property.datavalue;
-	const url = result.fileURL || result.originalUrl;
+	const url = result.fileUrl || result.originalUrl;
 
 	if (!url) {
 		return;

--- a/packages/client/src/constants.ts
+++ b/packages/client/src/constants.ts
@@ -9,7 +9,7 @@ export enum Properties {
 	LAST_SEEN = "lastSeen",
 	OKHV = "okhv",
 	TEST = "test",
-	FILE_URL = "fileURL",
+	FILE_URL = "fileUrl",
 	IMAGE = "image",
 	SOURCE = "source",
 	RELATED_TSDC = "relatedTsDC",

--- a/packages/client/src/queries/get-item.ts
+++ b/packages/client/src/queries/get-item.ts
@@ -115,7 +115,7 @@ export const GET_ITEM = gql`
 					result {
 						id
 						name
-						fileURL {
+						fileUrl {
 							...DataValue
 						}
 						originalUrl {

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -104,7 +104,7 @@ export interface HardwareData {
 	documentationReadinessLevel?: DataValueString;
 	export?: DataValue;
 	fileFormat?: DataValue;
-	fileURL?: DataValueString;
+	fileUrl?: DataValueString;
 	function?: DataValueString;
 	hasBoM?: DataValue;
 	hasComponent?: DataValueItem;


### PR DESCRIPTION
The fileURL fileUrl mismatch was the reason why (some?) images weren't
displayed on the detail pages.

Fixes #83 