### PR TITLE
Initialize data sources once, not per request

### DIFF
--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -20,10 +20,15 @@ app.use(helmet());
 app.use(compression());
 
 const startServer = async () => {
+  // initialize dataSources here so that they don't get created on every request
+  const sources = dataSources(
+    ELASTIC_API_URL,
+    WIKIBASE_API_URL,
+    QUERY_SERVICE_URL
+  );
   const server = new ApolloServer({
     schema,
-    dataSources: () =>
-      dataSources(ELASTIC_API_URL, WIKIBASE_API_URL, QUERY_SERVICE_URL),
+    dataSources: () => sources,
     plugins: [responseCachePlugin()],
   });
 


### PR DESCRIPTION
This turned out to be the cause of the race condition fixed in
6ce5d4d1e83a45011130ef5c9d049e2df7fa3a4f which was introduced in
4bfd100ed6bb35f84d8fc0ce328da3b5c6baf0eb. One of the data sources
fetches and then persists the Properties across requests. When the
dataSources init call was accidentally moved into the request context it
sometimes happened later than the requests fetching the item data.