### PR TITLE
Style Organization filter box as other dropdowns

### DIFF
--- a/packages/client/src/components/filter.css
+++ b/packages/client/src/components/filter.css
@@ -10,3 +10,8 @@
 .filter .ant-select:not(.ant-select-customize-input) .ant-select-selector {
 	background-color: #fff; /* for some reason it's a weird grey by default */
 }
+
+.filter .ant-select-selection-placeholder,
+.filter .ant-select-arrow {
+	color: rgba(0, 0, 0, 0.85);
+}


### PR DESCRIPTION
## Description

Styles the "placeholder" text and the dropdown arrow icon so it does not look greyed out like the filter field was disabled.
Makes the Organization filter field look like other filters.

## Related Issues

Addresses the Usability Issue number 5.