### PR TITLE
Disable Elasticsearch's Fuzzy Queries

### DIFF
--- a/packages/server/src/dataSources/elastic/index.ts
+++ b/packages/server/src/dataSources/elastic/index.ts
@@ -116,7 +116,7 @@ class ElasticDataSource extends DataSource {
   }
 
   private generateEntityTermsSearch(searchTerm: string) {
-    return { match: { text: { query: searchTerm, fuzziness: "AUTO" } } };
+    return { match: { text: { query: searchTerm } } };
   }
 
   private generateFunctionalDescriptionValueSearch(searchTerm: string) {


### PR DESCRIPTION
## Description

Switches Elasticsearch's fuzzy queries off (originally introduced in https://github.com/wmde/LOSH-Frontend/commit/3d581ae55218b1a75a69640f86d036b522f27aeb)
As reportedly leading to unexpected entries appearing in the search results.

## Related Issues

Attempts to address the usability issue no 16.