### PR TITLE
Added loading spinner to hardware table when data is being loaded

### DIFF
--- a/packages/client/src/components/hardware-table.tsx
+++ b/packages/client/src/components/hardware-table.tsx
@@ -76,6 +76,7 @@ const HardwareTable = (): JSX.Element => {
 		currentPage,
 		pageSize,
 		totalHits,
+		loadingData,
 	} = useContext(QueryContext);
 
 	const paginationState: PaginationProps = {
@@ -124,6 +125,7 @@ const HardwareTable = (): JSX.Element => {
 				dataSource={items}
 				size="middle"
 				pagination={false}
+				loading={loadingData}
 				style={{ overflowX: "scroll" }}
 				components={{
 					body: {

--- a/packages/client/src/context/query-context.tsx
+++ b/packages/client/src/context/query-context.tsx
@@ -15,6 +15,7 @@ interface QueryContextState {
 	currentPage: number;
 	pageSize: number;
 	totalHits: number;
+	loadingData: boolean;
 	handleSearchChange: (value: string) => void;
 	handlePageChange: (value: number) => void;
 	handlePageSizeChange: (value: number) => void;
@@ -30,6 +31,7 @@ export const QueryContext = React.createContext<QueryContextState>({
 	currentPage: 1,
 	pageSize: DEFAULT_PAGE_SIZE,
 	totalHits: 0,
+	loadingData: false,
 	handleSearchChange: () => undefined,
 	handlePageChange: () => undefined,
 	handlePageSizeChange: () => undefined,
@@ -139,6 +141,7 @@ export const QueryProvider: React.FC = ({ children }) => {
 				currentPage,
 				pageSize,
 				totalHits: data?.searchItems.total || 0,
+				loadingData: loading,
 				handleSearchChange,
 				handlePageChange,
 				handlePageSizeChange,


### PR DESCRIPTION
## Description

Adds a loading indicator over the hardware table when search data is being fetched.

## Related Issues

Addresses the Usability Issue no 10