### PR TITLE
Make organization filter a tag selection

### DIFF
--- a/packages/client/src/components/__tests__/__snapshots__/filter.test.tsx.snap
+++ b/packages/client/src/components/__tests__/__snapshots__/filter.test.tsx.snap
@@ -73,9 +73,9 @@ exports[`Filter renders correctly 1`] = `
       Organization
     </label>
     <Select
-      allowClear={true}
       filterOption={[Function]}
       id="organization"
+      mode="tags"
       onChange={[Function]}
       optionFilterProp="children"
       placeholder="Any Organization"

--- a/packages/client/src/components/filter.tsx
+++ b/packages/client/src/components/filter.tsx
@@ -138,13 +138,18 @@ const Filter: React.FC<FilterProps> = ({ filters, onFilterChange }) => {
 			<div className="filter-element">
 				<label htmlFor="organization">Organization</label>
 				<Select
-					allowClear
+					mode="tags"
 					style={{ width: 240 }}
 					showSearch
 					placeholder="Any Organization"
 					value={filters.organization}
 					optionFilterProp="children"
-					onChange={(val) => onFilterChange("organization", val)}
+					onChange={(val) => {
+						if (Array.isArray(val)) {
+							val = val.pop();
+						}
+						onFilterChange("organization", val);
+					}}
 					filterOption={(input, option) =>
 						option!.children.toLowerCase().indexOf(input.toLowerCase()) >= 0
 					}


### PR DESCRIPTION
## Description

Allows for picking and also deleting an organization using keyboard.
Includes a hack that always enforces a max. single organization to be picked. Also makes the value passed to the select field de facto incorrect -- as it is a multiselect nominally, the value should be an array.
Working this around makes the filters to continue work in search however.

## Related Issues

Addresses the Usability Issue no 6
