### PR TITLE
Use "Repository" as a label/field name, not "repo"

### DIFF
--- a/packages/client/src/components/detail-content.tsx
+++ b/packages/client/src/components/detail-content.tsx
@@ -95,7 +95,7 @@ const DetailContent: React.FC<DetailContentProps> = ({ pageData }) => {
 						rel="noreferrer"
 					>
 						<Button style={{ marginBottom: "1rem" }} id="repoBtn">
-							To {pageData.name} repo <ArrowRightOutlined />
+							To {pageData.name} repository <ArrowRightOutlined />
 						</Button>
 					</a>
 

--- a/packages/client/src/components/hardware-table.tsx
+++ b/packages/client/src/components/hardware-table.tsx
@@ -39,7 +39,7 @@ const columns: ColumnsType<HardwareData> = [
 		responsive: ["lg"],
 	},
 	{
-		title: "Repo",
+		title: "Repository",
 		key: Properties.REPO,
 		dataIndex: Properties.REPO,
 		ellipsis: true,
@@ -96,7 +96,7 @@ const HardwareTable = (): JSX.Element => {
 			ID: result.id,
 			Version: result.version?.datavalue.value,
 			License: result.spdxLicense?.datavalue.value,
-			Repo: result.repo?.datavalue.value,
+			Repository: result.repo?.datavalue.value,
 			Organisation: result.organisation?.datavalue.value,
 		}));
 		const csv = Papa.unparse(results);


### PR DESCRIPTION
## Description

Use a more clear full term instead of jargon-y "repo"

## Related Issues

Addresses the Usability Issue no 19
Note, it is a pull request into a branch of https://github.com/wmde/LOSH-Frontend/pull/127