### PR TITLE
Shorten git commit shas as version numbers to 8 characters

### DIFF
--- a/packages/client/src/components/__tests__/present-version.test.ts
+++ b/packages/client/src/components/__tests__/present-version.test.ts
@@ -1,0 +1,29 @@
+import { presentVersion } from "../present-version";
+
+describe("Version presenter", () => {
+	it("empty version remains an empty string", () => {
+		expect(presentVersion("")).toBe("");
+	});
+
+	it("regular version remains unchanged", () => {
+		expect(presentVersion("1.2.3")).toBe("1.2.3");
+	});
+
+	it("git commit sha is trimmed to 8 first characters", () => {
+		expect(presentVersion("abcdef1234567890abcdef123456789012345678")).toBe(
+			"abcdef12"
+		);
+	});
+
+	it("39-character string reminiscing git sha remains unchanged", () => {
+		expect(presentVersion("abcdef1234567890abcdef12345678901234567")).toBe(
+			"abcdef1234567890abcdef12345678901234567"
+		);
+	});
+
+	it("41-character string reminiscing git sha remains unchanged", () => {
+		expect(presentVersion("abcdef1234567890abcdef1234567890123456789")).toBe(
+			"abcdef1234567890abcdef1234567890123456789"
+		);
+	});
+});

--- a/packages/client/src/components/detail-content.tsx
+++ b/packages/client/src/components/detail-content.tsx
@@ -15,6 +15,7 @@ import SEO from "./seo";
 import "./detail-content.css";
 import Layout from "./layout";
 import useWindowSize from "../hooks/useWindowSize";
+import { presentVersion } from "./present-version";
 
 interface DetailContentProps {
 	pageData: any;
@@ -103,7 +104,7 @@ const DetailContent: React.FC<DetailContentProps> = ({ pageData }) => {
 
 					<DetailRowString
 						title="Version"
-						value={pageData.version?.datavalue.value}
+						value={presentVersion(pageData.version?.datavalue.value || "")}
 					/>
 
 					<DetailRowUrl

--- a/packages/client/src/components/hardware-table.tsx
+++ b/packages/client/src/components/hardware-table.tsx
@@ -11,6 +11,7 @@ import "./hardware-table.css";
 import DownloadOutlined from "@ant-design/icons/lib/icons/DownloadOutlined";
 import { Pagination } from "antd";
 import Papa from "papaparse";
+import { presentVersion } from "./present-version";
 
 const columns: ColumnsType<HardwareData> = [
 	{
@@ -23,7 +24,8 @@ const columns: ColumnsType<HardwareData> = [
 		title: "Version",
 		key: Properties.VERSION,
 		dataIndex: Properties.VERSION,
-		render: (v, record) => record.version?.datavalue.value,
+		render: (v, record) =>
+			presentVersion(record.version?.datavalue.value || ""),
 		responsive: ["lg"],
 		ellipsis: true,
 	},
@@ -94,7 +96,7 @@ const HardwareTable = (): JSX.Element => {
 		const results = items.map((result) => ({
 			Name: result.name,
 			ID: result.id,
-			Version: result.version?.datavalue.value,
+			Version: presentVersion(result.version?.datavalue.value || ""),
 			License: result.spdxLicense?.datavalue.value,
 			Repo: result.repo?.datavalue.value,
 			Organisation: result.organisation?.datavalue.value,

--- a/packages/client/src/components/present-version.ts
+++ b/packages/client/src/components/present-version.ts
@@ -1,0 +1,8 @@
+function presentVersion(version: string) {
+	if (version.length === 40 && version.match(/^[a-z0-9]+$/)) {
+		return version.substr(0, 8);
+	}
+	return version;
+}
+
+export { presentVersion };


### PR DESCRIPTION
For display

## Description

Very long git commit shas/IDs as version  numbers are making the UI not very readable.
Eight-character long git commit sha is equally good as an ID/version unique number.

## Related Issues

Attempts to address the Usability Issue no 11.
