### PR TITLE
Style active buttons as normal ones so they do not look confusing

### DIFF
--- a/packages/client/src/components/detail-content.css
+++ b/packages/client/src/components/detail-content.css
@@ -1,0 +1,5 @@
+.detail-button:active,
+.detail-button:focus {
+	color: rgba(0, 0, 0, 0.85);
+	border-color: rgba(0, 0, 0, 0.85);
+}

--- a/packages/client/src/components/detail-content.tsx
+++ b/packages/client/src/components/detail-content.tsx
@@ -94,7 +94,11 @@ const DetailContent: React.FC<DetailContentProps> = ({ pageData }) => {
 						target="_blank"
 						rel="noreferrer"
 					>
-						<Button style={{ marginBottom: "1rem" }} id="repoBtn">
+						<Button
+							style={{ marginBottom: "1rem" }}
+							id="repoBtn"
+							className="detail-button"
+						>
 							To {pageData.name} repo <ArrowRightOutlined />
 						</Button>
 					</a>

--- a/packages/client/src/components/detail-rows/detail-row-download.tsx
+++ b/packages/client/src/components/detail-rows/detail-row-download.tsx
@@ -24,7 +24,11 @@ function DetailRowDownload({ repoUrl }: DetailRowDownload) {
 	return (
 		<p>
 			<a href={generateDownloadUrl(repoUrl)} target="_blank" rel="noreferrer">
-				<Button icon={<DownloadOutlined />} id="downloadBtn">
+				<Button
+					icon={<DownloadOutlined />}
+					id="downloadBtn"
+					className="detail-button"
+				>
 					Download Bundle
 				</Button>
 			</a>

--- a/packages/client/src/components/hardware-table.css
+++ b/packages/client/src/components/hardware-table.css
@@ -52,3 +52,9 @@
 	.ant-select-selector {
 	background-color: white;
 }
+
+.hardware-table__footer .ant-btn:active,
+.hardware-table__footer .ant-btn:focus {
+	color: rgba(0, 0, 0, 0.85);
+	border-color: rgba(0, 0, 0, 0.85);
+}


### PR DESCRIPTION
## Description

When clicking away from the LOSH UI to the repository the browser keeps the button in active/focus state. After returning to LOSH site this might look confusing.
The change adjusts the focus/active styles of certain buttons

## Related Issues
Attempt to address the Usability Issue no 9.